### PR TITLE
Kerning values now scaled by font size

### DIFF
--- a/Typogenic/Scripts/TypogenicText.cs
+++ b/Typogenic/Scripts/TypogenicText.cs
@@ -341,7 +341,7 @@ public class TypogenicText : MonoBehaviour
 			float kerning = 0f;
 
 			if (prevGlyph != null)
-				kerning = prevGlyph.GetKerning(charCode);
+				kerning = prevGlyph.GetKerning(charCode) * Size;
 
 			if (vertexPointers != null)
 				vertexPointers.Add(m_Vertices.Count);
@@ -409,7 +409,7 @@ public class TypogenicText : MonoBehaviour
 			float kerning = 0f;
 
 			if (prevGlyph != null)
-				kerning = prevGlyph.GetKerning(charCode);
+				kerning = prevGlyph.GetKerning(charCode) * Size;
 
 			width += glyph.xAdvance * Size + Tracking + kerning;
 			prevGlyph = glyph;


### PR DESCRIPTION
Fixes issue of non-zero kerning being incorrect due to not being scaled by the font size anywhere.

The problem/fix can be demonstrated by comparing text such as "Te" in the Arial font in a large size.

Thanks for providing Typogenic! And it looks like i will be using it even with the new GUI.
