### PR TITLE
Fix undersized glyph bounding boxes for click support

### DIFF
--- a/Typogenic/Scripts/TypogenicText.cs
+++ b/Typogenic/Scripts/TypogenicText.cs
@@ -387,11 +387,7 @@ public class TypogenicText : MonoBehaviour
 			// Only need to store glyph bounds if click support is enabled.
 			if (EnableClickSupport)
 			{
-
-				// Click bounds for glyphs are based on allocated space, not rendered space.
-				// Otherwise we'll end up with unclickable dead zones between glyphs.
-				r.width = glyph.xAdvance * Size;
-				// And Y coordinates are just not handled the same at all.
+				// Y coordinates are just not handled the same at all.
 				r.y = -cursorY - r.height - glyph.yOffset * Size;
 
 


### PR DESCRIPTION
The removed line of code doesn't actually prevent unclickable dead zones, but it DOES sometimes lead
to the generated per-glyph bounding boxes used for click support to be too small (the demo's Arial letter 'j' is a good example.) This should alleviate the third problem discussed in #11.