### PR TITLE
Hotfixed API changes from Unity 5.X regarding cached components.

### DIFF
--- a/Typogenic/Scripts/TypogenicText.cs
+++ b/Typogenic/Scripts/TypogenicText.cs
@@ -56,7 +56,9 @@ public class TypogenicText : MonoBehaviour
 	protected List<Bounds> m_GlyphBounds = new List<Bounds>();
 	protected List<int>[] m_SubmeshTriangles;
 
-
+	// Cache components since they are no longer directly exposed:
+	protected new Renderer renderer;
+	
 	// Not the best way to track changes but Unity can't serialize properties,
 	// so it'll do the job just fine for now.
 	string _text;
@@ -105,6 +107,11 @@ public class TypogenicText : MonoBehaviour
 
 	void OnEnable()
 	{
+		if (renderer == null)
+		{
+			renderer = GetComponent<Renderer>();
+		}
+		
 		GetComponent<MeshFilter>().mesh = m_Mesh = new Mesh();
 		m_Mesh.name = "Text Mesh";
 		m_Mesh.hideFlags = HideFlags.HideAndDontSave;


### PR DESCRIPTION
As of Unity 5.X cached components are no longer available, and will throw an error when the files are dragged into Unity. These are the following errors it throws:

```
Assets/Temporarily/Typogenic/Typogenic/Scripts/TypogenicText.cs(166,34): error CS0619: `UnityEngine.Component.renderer' is obsolete: `Property renderer has been deprecated. Use GetComponent<Renderer>() instead. (UnityUpgradable)'
Assets/Temporarily/Typogenic/Typogenic/Scripts/TypogenicText.cs(166,43): error CS1061: Type `UnityEngine.Component' does not contain a definition for `sharedMaterials' and no extension method `sharedMaterials' of type `UnityEngine.Component' could be found (are you missing a using directive or an assembly reference?)
Assets/Temporarily/Typogenic/Typogenic/Scripts/TypogenicText.cs(256,39): error CS0619: `UnityEngine.Component.renderer' is obsolete: `Property renderer has been deprecated. Use GetComponent<Renderer>() instead. (UnityUpgradable)'
Assets/Temporarily/Typogenic/Typogenic/Scripts/TypogenicText.cs(256,48): error CS1061: Type `UnityEngine.Component' does not contain a definition for `sharedMaterials' and no extension method `sharedMaterials' of type `UnityEngine.Component' could be found (are you missing a using directive or an assembly reference?)

```

It can be automaticly fixed using their update tool, but I changed the code so it won't throw the errors and require the update tool. These changes work fine on any previous version of Unity as well, as the changes I did, was just what was hidden behind the original cached calls. The total extend of the code is simple a null check and component getting, and a variable to store it in. I've even kept the name to 'renderer' so it won't require any changes to the remaining code.