### PR TITLE
Changes as a result of Unity 5.X patches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Typogenic
 
 **Typogenic** is an easy to use, fast and high-quality 3D text renderer with a very low memory footprint.
 
-Requires Unity 4.3+ and works with Unity Free.
+Requires Unity 4.3+, tested in Unity 5.5, and works with Unity Personal (Free).
 
 Instructions
 ------------

--- a/Typogenic/Editor/TypogenicFontWizard.cs
+++ b/Typogenic/Editor/TypogenicFontWizard.cs
@@ -27,7 +27,7 @@ public class TypogenicFontWizard : ScriptableWizard
 		{
 			string atlasPath = AssetDatabase.GetAssetPath(Atlas);
 			TextureImporter importer = (TextureImporter)AssetImporter.GetAtPath(atlasPath);
-			importer.textureType = TextureImporterType.Advanced;
+			importer.textureType = TextureImporterType.Default;
 			importer.mipmapEnabled = false;
 			importer.anisoLevel = 4;
 			importer.filterMode = FilterMode.Bilinear;

--- a/Typogenic/Editor/TypogenicTextEditor.cs
+++ b/Typogenic/Editor/TypogenicTextEditor.cs
@@ -51,7 +51,11 @@ public class TypogenicTextEditor : Editor
 	{
 		serializedObject.Update();
 
-		EditorGUIUtility.LookLikeControls();
+		/*
+		 *	This method has been deprecated:
+		 *
+		 *	EditorGUIUtility.LookLikeControls();
+		 */
 
 		EditorGUILayout.PropertyField(m_Font);
 		EditorGUILayout.PropertyField(m_GenerateNormals);


### PR DESCRIPTION

1)
Changed TypogenicFontWizard.cs, a setting from Advanced to Default (as to avoid the automatic API script from doing it anyway).

2)
Outcommented the LookLikeInspector from TypogenicTextEditor.cs, as it's no longer supported and the default behaviour is the same.

3)
Updated the readme, to reflect the name change from Unity Free to Unity Personal.
